### PR TITLE
Fix local storage directory creation

### DIFF
--- a/lib/imager/store/local.ex
+++ b/lib/imager/store/local.ex
@@ -30,7 +30,7 @@ defmodule Imager.Store.Local do
     dir = Keyword.get(opts, :dir, ".")
     full_path = Path.join(dir, path)
 
-    :ok = File.mkdir_p!(dir)
+    :ok = full_path |> Path.dirname() |> File.mkdir_p!()
 
     {:ok, file} = :file.open(full_path, [:write, :raw])
 


### PR DESCRIPTION
Earlier we were creating only top-level storage directory, however we
were assuming that the path for the file was existing.  This fixes that
by always trying to create full path for the given file.