### PR TITLE
Use monitors to track execution status

### DIFF
--- a/lib/imager.ex
+++ b/lib/imager.ex
@@ -59,6 +59,7 @@ defmodule Imager do
           {:ok, {:unknown, mime, stream}}
 
         _ ->
+          Logger.error("Processing image failed")
           Instrumenter.Processing.failed(store)
 
           :failed

--- a/lib/imager/tool.ex
+++ b/lib/imager/tool.ex
@@ -74,5 +74,6 @@ defmodule Imager.Tool do
   defp string({"gravity", orientation}), do: {:gravity, orientation}
   defp string({"strip", _}), do: {:strip, true}
   defp string({"thumbnail", size}), do: {:thumbnail, size}
+  defp string({"format", format}), do: {:format, format}
   defp string(option), do: raise(UnknownOption, option)
 end

--- a/test/imager/runner_test.exs
+++ b/test/imager/runner_test.exs
@@ -24,16 +24,6 @@ defmodule Imager.RunnerTest do
     assert_receive {:out, ^pid, "foo"}
   end
 
-  test "returns success on exit" do
-    assert {:ok, pid} = run("true")
-    assert_receive {:exit, ^pid, :success}
-  end
-
-  test "returns failure on exit" do
-    assert {:ok, pid} = run("false")
-    assert_receive {:exit, ^pid, :failure}
-  end
-
   defp run(command, args \\ []),
     do: start_supervised({Subject, pid: self(), cmd: command, args: args})
 end


### PR DESCRIPTION
It replaces old behaviour that relied on manual message passing.  Now we
use monitoring functionality of the OTP which removes need to resend
messages in Imager.Runnner.wait/1 and Imager.Runner.stream/1-2.