### PR TITLE
Handle case when process already ended

### DIFF
--- a/lib/imager/runner.ex
+++ b/lib/imager/runner.ex
@@ -36,6 +36,7 @@ defmodule Imager.Runner do
 
     receive do
       {:DOWN, ^ref, :process, ^pid, :normal} -> :ok
+      {:DOWN, ^ref, :process, ^pid, :noproc} -> :ok
       {:DOWN, ^ref, :process, ^pid, _} -> :error
     end
   end


### PR DESCRIPTION
As there is no way to differentiate between "already ended" and "never
existed" PIDs it will return `:ok` even when provided never-existing
PID.