### PR TITLE
add build-base to final stage, source stage is unecessary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,8 @@
-FROM alpine:latest AS source
+FROM elixir:1.7.4-alpine AS build
 RUN apk add --no-cache --update \
-    bash \
-    ghostscript \
-    imagemagick \
-    libcap \
-    openssl \
-    sudo \
-    tini
-ENV LANG C.UTF-8
-ENV PORT 80
-ENV IMAGER_USER nobody
-HEALTHCHECK --timeout=5s --interval=10s CMD imager ping
-ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/imager"]
-CMD ["foreground"]
-
-FROM elixir:1.7.3-alpine AS build
-RUN apk add --update \
     build-base \
     git \
-    libcap-dev \
-    && rm -rf /var/cache/apk/*
+    libcap-dev
 ENV MIX_ENV prod
 ENV OPTIMIZE true
 RUN mkdir /app
@@ -31,6 +14,21 @@ RUN mix do deps.get, deps.compile
 COPY . /app
 RUN mix do compile, release --env=prod
 
-FROM source
+FROM alpine:latest
 MAINTAINER Łukasz Jan Niemier <lukasz.niemier@appunite.com>
+RUN apk add --no-cache --update \
+    build-base \
+    bash \
+    ghostscript \
+    imagemagick \
+    libcap \
+    openssl \
+    sudo \
+    tini
+ENV LANG C.UTF-8
+ENV PORT 80
+ENV IMAGER_USER nobody
 COPY --from=build /app/_build/prod/rel/imager /usr/local
+HEALTHCHECK --timeout=5s --interval=10s CMD imager ping
+ENTRYPOINT ["tini", "--", "/usr/local/bin/imager"]
+CMD ["foreground"]


### PR DESCRIPTION
with multi sage and without `build-base` lib `prometheus_process_collector` is going to crash
```
Wait 1s to mitigate race condition in Distillery config
2019-04-11 11:42:30.907195 crash_report        #{label=>{proc_lib,crash},report=>[[{initial_call,{supervisor,kernel,['Argument__1']}},{pid,<0.1485.0>},{registered_name,[]},{error_info,{exit,{on_load_function_failed,prometheus_process_collector},[{init,run_on_load_handlers,0,[]},{kernel,init,1,[{file,"kernel.erl"},{line,212}]},{supervisor,init,1,[{file,"supervisor.erl"},{line,295}]},{gen_server,init_it,2,[{file,"gen_server.erl"},{line,374}]},{gen_server,init_it,6,[{file,"gen_server.erl"},{line,342}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,249}]}]}},{ancestors,[kernel_sup,<0.1460.0>]},{message_queue_len,0},{messages,[]},{links,[<0.1462.0>]},{dictionary,[]},{trap_exit,true},{status,running},{heap_size,376},{stack_size,27},{reductions,273}],[]]}
```